### PR TITLE
exporting InTransport type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,12 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-      - name: Setup golang 1.18
+      - name: Setup golang 1.19
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.19'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
       - name: Add hosts
         run: cat ${GITHUB_WORKSPACE}/hosts | sudo tee -a /etc/hosts
       - name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+linters:
+  enable:
+    - revive
+issues:
+  include:
+    - EXC0012
+    - EXC0013
+    - EXC0014
+    - EXC0015
+linters-settings:
+  revive:
+    ignore-generated-header: true
+
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id

--- a/cache.go
+++ b/cache.go
@@ -46,7 +46,7 @@ type certCache struct {
 
 // NewMapCache - returns a Cacher implementation based on a go map and mutexes.
 func NewMapCache() Cacher {
-	return &certCache {
+	return &certCache{
 		m: make(map[string]*certCacheEntry),
 	}
 }
@@ -68,9 +68,9 @@ func (cc *certCache) LockedCachedCert(key string) LockedCachedCertRepresenter {
 	return cce
 }
 
-type nopCache struct {}
+type nopCache struct{}
 
-type nopCacheEntry struct {}
+type nopCacheEntry struct{}
 
 // NewNopCache - this returns a nop cache, which can be used to disable caching of certificates.
 func NewNopCache() Cacher {
@@ -81,22 +81,12 @@ func (nc nopCache) LockedCachedCert(_ string) LockedCachedCertRepresenter {
 	return nopCacheEntry{}
 }
 
-func (nce nopCacheEntry) LockEntry() {
-	return
-}
+func (nce nopCacheEntry) LockEntry() {}
 
-func (nce nopCacheEntry) Unlock() {
-	return
-}
+func (nce nopCacheEntry) Unlock() {}
 
-func (nce nopCacheEntry) UnlockCacher() {
-	return
-}
+func (nce nopCacheEntry) UnlockCacher() {}
 
-func (nce nopCacheEntry) Cert() *x509.Certificate {
-	return nil
-}
+func (nce nopCacheEntry) Cert() *x509.Certificate { return nil }
 
-func (nce nopCacheEntry) SetCert(_ *x509.Certificate) {
-	return
-}
+func (nce nopCacheEntry) SetCert(_ *x509.Certificate) {}

--- a/doc.go
+++ b/doc.go
@@ -1,7 +1,7 @@
 // Package intransport implements the http RoundTripper interface.  This can
 // be used with, for example, http.Client and httputil.ReverseProxy. This
 // package is meant to allow secure communications with remote hosts that may
-// not fully specify their intermediate certificates on the TLS handshake.
+// not fully specify their intermediate certificates on the tlsc handshake.
 // Most browsers support communication with these hosts by using the issuing
 // certificate URL from the Authority Information Access extension of the cert
 // to fetch any missing intermediates.  Each intermediate is fetched in turn

--- a/intransport_test.go
+++ b/intransport_test.go
@@ -37,7 +37,7 @@ type intMeta struct {
 	caIssuerURL string
 }
 
-func (im *intMeta) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (im *intMeta) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/x-x509-ca-cert")
 	w.WriteHeader(http.StatusOK)
 	buf := bytes.NewReader(im.cert.Raw)


### PR DESCRIPTION
exporting IntermediateHTTPClient field for overriding the
intermediate certificate fetching http client.

removing unused methods per golangci-lint

removing redundant returns per golangci-lint

updating workflow to use golang 1.19 toolchain

observing passed tls.Connection's VerifyConnection if set,
and if so populate the InTransport.NextVerifyConnection

make return from NewMethods the concrete type

update workflow to include golangci-lint

adding .golangci.yml